### PR TITLE
Fixes find_route error due to XF 1.5 incompatibility

### DIFF
--- a/library/ThemeHouse/SocialGroups/Extend/XenForo/Route/Prefix/Forums.php
+++ b/library/ThemeHouse/SocialGroups/Extend/XenForo/Route/Prefix/Forums.php
@@ -29,10 +29,16 @@ class ThemeHouse_SocialGroups_Extend_XenForo_Route_Prefix_Forums extends XFCP_Th
                 $routeFilters = XenForo_Application::get('routeFiltersOut');
                 if (isset($routeFilters['social-forums'])) {
                     foreach ($routeFilters['social-forums'] as $filter) {
-                        list ($from, $to) = XenForo_Link::translateRouteFilterToRegex($filter['find_route'],
-                            $filter['replace_route']);
+                        if (array_key_exists('find_route',$filter) && array_key_exists('replace_route',$filter)) {
+                            list ($from, $to) = XenForo_Link::translateRouteFilterToRegex($filter['find_route'],
+                                $filter['replace_route']);
 
-                        $newLink = preg_replace($from, $to, $link);
+                            $newLink = preg_replace($from, $to, $link);
+                        }
+                        else {
+                            $newLink = $link;
+                        }
+                        
                         if ($newLink != $link) {
                             $link = $newLink;
                             break;


### PR DESCRIPTION
This fixes an issue originally reported on the Xenforo community [here](https://xenforo.com/community/threads/th-social-groups.34152/page-57#post-970722) using the solution described [here](https://xenforo.com/community/threads/th-social-groups.34152/page-57#post-970723). The change never made it into an official version before Social Groups was open-sourced. I've been using this fix successfully on my own installation for about a year. Upgrading to the current release of Social Groups on GitHub caused my forum to break due to an incompatibility with XF 1.5, and this fixes that.
